### PR TITLE
Makes responsive navbar scrollable

### DIFF
--- a/assets/scss/_nav.scss
+++ b/assets/scss/_nav.scss
@@ -52,7 +52,7 @@
                 display: inline-block;
                 height: 50px;
 
-                @include media-breakpoint-down(md) {
+                @include media-breakpoint-down(sm) {
                     left: 16px;
                     width: 80px;
                     height: auto;
@@ -71,6 +71,13 @@
         font-weight: $font-weight-bold;
     }
 
+    .td-navbar-nav-scroll {
+        max-width: 100%;
+        .navbar-nav {
+            overflow-x: auto;
+        }
+    }
+
     .td-search-input {
         border: none;
 
@@ -83,9 +90,10 @@
         min-width: 100px;
     }
 
-    @include media-breakpoint-down(md) {
+    @include media-breakpoint-down(sm) {
         padding-right: .5rem;
         padding-left: .75rem;
-        align-items: flex-end;
+        align-items: center;
     }
+
 }


### PR DESCRIPTION
The nav bar was getting cut off at lower viewport widths
![image](https://user-images.githubusercontent.com/9147195/99007890-56b81900-2502-11eb-8942-2bd0b593c934.png)

This patch adds a scrollbar to the navbar when the links overflow

![image](https://user-images.githubusercontent.com/9147195/99007992-8c5d0200-2502-11eb-9427-b1cd596f6b53.png)
