### PR TITLE
Increase contrast of body text

### DIFF
--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -5,8 +5,11 @@ Add styles or override the theme's variables here.
   // Theme colors
   $enable-gradients: false;
   $enable-shadows: false;
+
+  $link-color: #156E85;
   
-  $primary: #1985A1;
+  $primary: #156E85;
+  $blue: #1D97B5;
   $secondary: #FFFFFF;
   $info: #46494C;
   $dark: #46494C;


### PR DESCRIPTION
WCAG guidelines recommend a contrast ratio of at least 4.5 to
accomodate users with different vision capabilities. This tweaks
the palette a bit to suit the guidelines.